### PR TITLE
fix(#22): Calendar picker — replace TreeDropdownField with Calendar DropdownField

### DIFF
--- a/src/Elements/ElementCalendar.php
+++ b/src/Elements/ElementCalendar.php
@@ -93,7 +93,11 @@ class ElementCalendar extends BaseElement
             $fields->addFieldsToTab(
                 'Root.Main',
                 [
-                    $fields->dataFieldByName('CalendarID'),
+                    DropdownField::create(
+                        'CalendarID',
+                        _t(__CLASS__ . '.CalendarLabel', 'Calendar'),
+                        Calendar::get()->map('ID', 'Title')
+                    )->setEmptyString(''),
                     $fields->dataFieldByName('Limit'),
                 ],
                 'Content'

--- a/tests/Elements/ElementCalendarTest.php
+++ b/tests/Elements/ElementCalendarTest.php
@@ -8,6 +8,7 @@ use Dynamic\Calendar\Page\Calendar;
 use Dynamic\Calendar\Page\EventPage;
 use Dynamic\Elements\Calendar\Elements\ElementCalendar;
 use SilverStripe\Dev\SapphireTest;
+use SilverStripe\Forms\DropdownField;
 use SilverStripe\ORM\ArrayList;
 use SilverStripe\Versioned\Versioned;
 
@@ -278,6 +279,26 @@ class ElementCalendarTest extends SapphireTest
         // Should have multiple instances from the recurring event
         $this->assertGreaterThan(1, $events->count());
         $this->assertLessThanOrEqual(10, $events->count()); // Allow for more instances due to limit
+    }
+
+    /**
+     * Test that getCMSFields renders CalendarID as a plain DropdownField,
+     * not a scaffolded TreeDropdownField (SS6 has_one-to-SiteTree regression).
+     */
+    public function testGetCMSFieldsCalendarIdIsDropdownField()
+    {
+        /** @var ElementCalendar $element */
+        $element = $this->objFromFixture(ElementCalendar::class, 'one');
+
+        $fields = $element->getCMSFields();
+        $field = $fields->dataFieldByName('CalendarID');
+
+        $this->assertNotNull($field, 'CalendarID field should be present');
+        $this->assertSame(
+            DropdownField::class,
+            get_class($field),
+            'Calendar picker must be a plain DropdownField, not a tree picker or searchable subclass'
+        );
     }
 
     /**

--- a/tests/Elements/ElementCalendarTest.php
+++ b/tests/Elements/ElementCalendarTest.php
@@ -299,6 +299,18 @@ class ElementCalendarTest extends SapphireTest
             get_class($field),
             'Calendar picker must be a plain DropdownField, not a tree picker or searchable subclass'
         );
+
+        // The source must be Calendar pages only (ID => Title), not the whole site tree.
+        $source = $field->getSource();
+        $calendarOne = $this->objFromFixture(Calendar::class, 'one');
+        $calendarTwo = $this->objFromFixture(Calendar::class, 'two');
+
+        $this->assertArrayHasKey($calendarOne->ID, $source);
+        $this->assertSame('My Awesome Calendar', $source[$calendarOne->ID]);
+        $this->assertArrayHasKey($calendarTwo->ID, $source);
+        $this->assertSame('My Other Awesome Calendar', $source[$calendarTwo->ID]);
+
+        $this->assertSame('', $field->getEmptyString(), 'Field should allow an empty/no-calendar selection');
     }
 
     /**


### PR DESCRIPTION
## Summary
- `ElementCalendar::getCMSFields()` reused the auto-scaffolded `CalendarID` field, which SS6 renders as a `TreeDropdownField` (whole-site-tree page picker) because the `Calendar` has_one points at a SiteTree subclass.
- Replaces it with an explicit `DropdownField::create('CalendarID', ..., Calendar::get()->map('ID', 'Title'))->setEmptyString('')`, matching the identical fix already shipped in the sibling module `dynamic/silverstripe-elemental-blog` (`ElementBlogPosts`, PR #67 / commit `f4f75df047fd63339870c52f8d576ef3c678abbf`).
- Editors previously could save an empty/invalid `CalendarID` via the confusing tree picker, which silently breaks front-end event loading (`$Calendar.Link/events` AJAX call resolves to nothing).

Closes #22

## Test plan
- [x] Added `testGetCMSFieldsCalendarIdIsDropdownField` asserting `CalendarID` scaffolds to exactly `SilverStripe\Forms\DropdownField`, not a tree picker or searchable subclass.
- [x] `vendor/bin/phpcs vendor/dynamic/silverstripe-elemental-dynamic-calendar/src` — compared against unmodified baseline; error count/pattern unchanged (all pre-existing, none in the touched `getCMSFields()` region).
- [x] `vendor/bin/phpstan analyse vendor/dynamic/silverstripe-elemental-dynamic-calendar/src` — 7 errors, identical to baseline, none related to the change.
- [ ] `vendor/bin/phpunit vendor/dynamic/silverstripe-elemental-dynamic-calendar/tests` — the whole suite's shared `setUp()` fails on both the baseline and this branch (pre-existing `EventPage::validate()` error "Selected parent must be a Calendar page." from `dynamic/silverstripe-calendar`, unrelated to this change and out of scope here).